### PR TITLE
Use much more narrow mixin to remove only validation for only gamma

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ repositories {
 	}
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/holo-utils.classtweaker")
+}
+
 dependencies {
 	// To change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"

--- a/src/main/java/com/poggers/mixin/OverrideIllegalMixin.java
+++ b/src/main/java/com/poggers/mixin/OverrideIllegalMixin.java
@@ -1,5 +1,7 @@
 package com.poggers.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.option.SimpleOption;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.text.Text;
@@ -9,10 +11,11 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.mojang.serialization.Codec;
+
+import java.util.Optional;
 
 @Mixin(SimpleOption.class)
 public class OverrideIllegalMixin<T> {
@@ -30,10 +33,9 @@ public class OverrideIllegalMixin<T> {
         }
     }
 
-    @Inject(method = "setValue", at = @At("HEAD"), cancellable = true)
-    private void setOverrideValue(T value, CallbackInfo info){
-        this.value = value;
-        info.cancel();
+    @WrapOperation(method = "setValue", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/SimpleOption$Callbacks;validate(Ljava/lang/Object;)Ljava/util/Optional;"))
+    private Optional<T> cancelValidation(SimpleOption.Callbacks instance, T t, Operation<Optional<T>> original) {
+        return text.getString().equals(I18n.translate("options.gamma")) ? Optional.of(t) : original.call(instance, t);
     }
 
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,5 +31,6 @@
 		"java": ">=21",
 		"fabric-api": "*",
 		"cloth-config": ">=21.0.0"
-	}
+	},
+	"accessWidener": "holo-utils.classtweaker"
 }

--- a/src/main/resources/holo-utils.classtweaker
+++ b/src/main/resources/holo-utils.classtweaker
@@ -1,0 +1,2 @@
+classTweaker  v1  named
+accessible class net/minecraft/client/option/SimpleOption$Callbacks


### PR DESCRIPTION
This allows mc's change callbacks to run is generally more compatible with other mods targeting the same mixin point. This change should be applicable to most of the other fullbright-nofog branches.